### PR TITLE
Unrecognized escape sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Task("RebuildDatabase")
 		AliaSql("Rebuild", new AliaSqlSettings
 		{
 			ToolPath = "./tools/AliaSQL/tools/AliaSQL.exe",
-			ConnectionString = ".\sqldb",
+			ConnectionString = ".\\sqldb",
 			DatabaseName = "TestDatabase",
 			ScriptsFolder = "./src/Database/Scripts",
 		});


### PR DESCRIPTION
Fixed C# syntax error in sample ".\sqldb" -> ".\sqldb"
