### PR TITLE
Don't add anchor to header

### DIFF
--- a/docs/input/_Bottom.cshtml
+++ b/docs/input/_Bottom.cshtml
@@ -12,7 +12,7 @@
 <script type="text/javascript" src="@Context.GetLink("/assets/js/clipboard.min.js")"></script>
 <script type="text/javascript">
     anchors.options.placement = 'left';
-    anchors.add();
+    anchors.add('#content > h1,h2,h3,h4');
 
     var snippets = document.querySelectorAll("pre > code");
     [].forEach.call(snippets, function(snippet) {


### PR DESCRIPTION
Currently anchors are added to all headings. This limits it to only headers in the content area and not the `h1` in the title banner